### PR TITLE
Moved create patient out of navbar

### DIFF
--- a/client/src/components/navbar.js
+++ b/client/src/components/navbar.js
@@ -34,15 +34,6 @@ export default function Navbar() {
        >
          <span className="navbar-toggler-icon"></span>
        </button>
-        <div className="collapse navbar-collapse" id="navbarSupportedContent">
-         <ul className="navbar-nav ml-auto">
-           <li className="nav-item">
-             <NavLink className="nav-link" style={{position: 'fixed', right: 0}} to="/create">
-               Create Patient
-             </NavLink>
-           </li>
-         </ul>
-       </div>
      </nav>
    </div>
  );

--- a/client/src/components/recordList.js
+++ b/client/src/components/recordList.js
@@ -93,6 +93,15 @@ export default function RecordList() {
         </thead>
         <tbody>{recordList()}</tbody>
       </table>
+      <div>
+         <ul className="navbar-nav ml-auto">
+           <li className="nav-item">
+             <Link style={{paddingLeft: '20px', position: 'fixed'}} to="/create">
+               Create New Patient
+             </Link>
+           </li>
+         </ul>
+       </div>
     </div>
   );
 }


### PR DESCRIPTION
New implementation has "Create new patient" trail underneath the patient list. Might want to change it if Rebecca expects us to have more than a full screen full of patients but for now looks cool.