### PR TITLE
Added date filtering for trends.

### DIFF
--- a/client/src/components/trends/individualTrends.js
+++ b/client/src/components/trends/individualTrends.js
@@ -28,6 +28,9 @@ const IndividualTrends = () => {
                     <tr>
                         <TrendTableEntry id = {id} />
                     </tr>
+                    <tr>
+                        <TrendTableEntry id = {id} />
+                    </tr>
                 </tbody>
             </table>
         );

--- a/client/src/components/trends/trendTableEntry.js
+++ b/client/src/components/trends/trendTableEntry.js
@@ -7,8 +7,18 @@ const TrendTableEntry = ({id}) => {
     // Set the selected calculation, for filtering
     const [selectedCalculation, setSelectedCalculation] = useState("");
 
-    // Filer used for charts that filters them by patient ID and the valueType (aka Formula)
-    const filter = {"patient_id" : id , "valueType" : selectedCalculation.name}
+    // Default start date
+    const defaultStartDate = "2023-01-01";
+
+    // Default end date (current date)
+    const defaultEndDate = new Date().toString();
+
+    // State variables for start date and end date
+    const [startDate, setStartDate] = useState(defaultStartDate);
+    const [endDate, setEndDate] = useState(defaultEndDate);
+
+    // Filter used for charts that filters them by patient ID, date, and the valueType (aka Formula)
+    const filter = {"patient_id" : id , "valueType" : selectedCalculation.name, "date" :  { $gte: new Date(startDate), $lt: new Date(endDate) }}
 
     // Possible calculations, for the dropdown menu
     const calculations = [
@@ -47,6 +57,21 @@ const TrendTableEntry = ({id}) => {
         );
     }
 
+    /**
+     * Sets the start date to whatever the user specifies in the "Start Date" text box.
+     */
+    const handleStartDateChange = (event) => {
+        setStartDate(event.target.value);
+    };
+
+    /**
+     * Sets the end date to whatever the user specifies in the "Start Date" text box.
+     */
+    const handleEndDateChange = (event) => {
+        setEndDate(event.target.value);
+    };
+
+
     return (
         <div>
             <form>
@@ -54,6 +79,14 @@ const TrendTableEntry = ({id}) => {
                     Calculation:
                     <DropdownButton id="dropdown-basic-button" title={selectedCalculation.name}>{calculationList()}</DropdownButton>
                 </label>
+                    <label>
+                        Start Date:
+                        <input type="date" value={startDate} onChange={handleStartDateChange} />
+                    </label>
+                    <label>
+                        End Date:
+                        <input type="date" value={endDate} onChange={handleEndDateChange} />
+                    </label>
             </form>
 
             <div style={{ display: 'inline-block' }}>


### PR DESCRIPTION
Added date filtering for trends. Users can select a start and end date they want (calendar drop down or text option), and the trends will automatically filter for this range. Start date is defaulted tp 2023-01-01, end date is defaulted to the current day.

![date_filter](https://github.com/NamkhangNLe/Hemodynamics-Calculator-JIC-3343/assets/114538345/39b7a05f-322e-4339-9b73-39e4c035bab7)
