### PR TITLE
Add print functionality to individual trends page

### DIFF
--- a/client/src/components/trends/individualTrends.js
+++ b/client/src/components/trends/individualTrends.js
@@ -38,11 +38,17 @@ const IndividualTrends = () => {
 
     const viewLink = `/view/${id}`;
 
+    const handlePrint = () => {
+        window.print();
+    }
+
+    
     return(
         <div>
             <div>
                 <Link to={viewLink}> <button> View Patient Profile</button></Link>
                 <Link to="/trends"> <button> View Other Patient Trends </button></Link>
+                <button onClick={handlePrint}>Save as PDF</button>
             </div>
 
             {trendsTable()}


### PR DESCRIPTION
A bit rudimentary but I have tried HTML2Canvas and three other libraries. The issues lies in the fact that these graphs are n ot rendered in the DOM but instead are pulled from Mongo Graphs. @MichaelEHammond when you record make sure you try doing control p and clicking save as pdf as your default option when printing. Therefore when the button is pressed it does the same on live video.