### PR TITLE
super small fix for the dropdown menu in trends page

### DIFF
--- a/client/src/pages/trends.js
+++ b/client/src/pages/trends.js
@@ -55,12 +55,7 @@ const Trends = () => {
         <div>
             <h3>Patient Trends</h3>
             <p className="subheading">View patient trends for selected calculations.</p>
-            <form>
-                <label>
-                    Select Patient:
-                    <DropdownButton id="dropdown-basic-button" title={selectedPatient}>{patientList()}</DropdownButton>
-                </label>
-            </form>
+            <DropdownButton id="dropdown-basic-button" title={selectedPatient}>{patientList()}</DropdownButton>
         </div>
     );
 }


### PR DESCRIPTION
The dropdown menu did not need to be in a <form> component. This messed with the spacing of the page. Also removed the redundant "select patient" text above the dropdown.