### PR TITLE
Bug fix: empty array no longer in hardware field.

### DIFF
--- a/client/src/components/create.js
+++ b/client/src/components/create.js
@@ -17,7 +17,7 @@ export default function Create() {
         medications: "",
         notes: "",
         archived: false,
-        hardware: [[]]
+        hardware: []
     });
 
 


### PR DESCRIPTION
Fixed a bug where the first entry of the hardware field for patient profiles as an empty array. 